### PR TITLE
To networkx

### DIFF
--- a/neet/automata/eca.py
+++ b/neet/automata/eca.py
@@ -515,3 +515,34 @@ class ECA(object):
         """
         # Outgoing neighbors are a subset of incoming neighbors.
         return self.neighbors_in(index, size)
+
+    def to_networkx_graph(self,size):
+        """
+        Return networkx graph given neet network.  Requires networkx.
+
+        :param size: size of ECA, required if network is an ECA
+        :returns : a networkx DiGraph
+        """
+
+        edges = []
+        for i in range(size):
+            for j in self.neighbors_out(i,size):
+                edges.append((i,j))
+
+        return nx.DiGraph(edges,code=self.code,size=self.size,boundary=self.boundary)
+
+    def draw(self,size,filename=None):
+        """
+        Output a file with a simple network drawing.  
+        
+        Requires networkx and pygraphviz.
+        
+        Supported image formats are determined by graphviz.  In particular,
+        pdf support requires 'cairo' and 'pango' to be installed prior to
+        graphviz installation.
+
+        :param filename: filename to write drawing to. Temporary filename will be used if no filename provided.
+        :param size: size of ECA, required if network is an ECA
+        :returns: a pygraphviz network drawing
+        """        
+        nx.nx_agraph.view_pygraphviz(self.to_networkx_graph(size),prog='circo',path=filename)

--- a/neet/boolean/logicnetwork.py
+++ b/neet/boolean/logicnetwork.py
@@ -4,6 +4,7 @@
 import re
 from neet.statespace import StateSpace
 from neet.exceptions import FormatError
+import networkx as nx
 
 
 class LogicNetwork(object):
@@ -613,7 +614,7 @@ class LogicNetwork(object):
         """
         return self.neighbors_in(index) | self.neighbors_out(index)
 
-    def to_networkx_graph(self,labels='names'):
+    def to_networkx_graph(self,labels='indices'):
         """
         Return networkx graph given neet network.  Requires networkx.
 
@@ -621,21 +622,36 @@ class LogicNetwork(object):
                        ('names' or 'indices')
         :returns: a networkx DiGraph
         """
-        if labels = 'names':
-            if hasattr(net,'names'):
-                labels = net.names
+        if labels == 'names':
+            if hasattr(self,'names'):
+                labels = self.names
             else:
                 raise ValueError("network nodes do not have names")
 
-        elif labels = 'indices':
-            labels = range(net.size)
+        elif labels == 'indices':
+            labels = range(self.size)
 
         else:
             raise ValueError("labels must be 'names' or 'indices'")
 
         edges = []
-        for i,label in enumerate(net.labels):
-            for j in net.neighbors_out(i):
+        for i,label in enumerate(labels):
+            for j in self.neighbors_out(i):
                 edges.append((labels[i],labels[j]))
 
-        return nx.DiGraph(edges,name=net.metadata.get('name'))
+        return nx.DiGraph(edges,name=self.metadata.get('name'))
+
+    def draw(self,labels='indices',filename=None):
+        """
+        Output a file with a simple network drawing.  
+        
+        Requires networkx and pygraphviz.
+        
+        Supported image formats are determined by graphviz.  In particular,
+        pdf support requires 'cairo' and 'pango' to be installed prior to
+        graphviz installation.
+
+        :param format: 
+
+        """        
+        nx.nx_agraph.view_pygraphviz(self.to_networkx_graph(labels=labels),prog='circo',path=filename)

--- a/neet/boolean/logicnetwork.py
+++ b/neet/boolean/logicnetwork.py
@@ -651,7 +651,10 @@ class LogicNetwork(object):
         pdf support requires 'cairo' and 'pango' to be installed prior to
         graphviz installation.
 
-        :param format: 
+        :param labels: how node is labeled and thus identified in networkx graph 
+                   ('names' or 'indices'), only used if network is a LogicNetwork or WTNetwork
+        :param filename: filename to write drawing to. Temporary filename will be used if no filename provided.
+        :returns: a pygraphviz network drawing
 
         """        
         nx.nx_agraph.view_pygraphviz(self.to_networkx_graph(labels=labels),prog='circo',path=filename)

--- a/neet/boolean/logicnetwork.py
+++ b/neet/boolean/logicnetwork.py
@@ -612,3 +612,30 @@ class LogicNetwork(object):
             set([0, 2])
         """
         return self.neighbors_in(index) | self.neighbors_out(index)
+
+    def to_networkx_graph(self,labels='names'):
+        """
+        Return networkx graph given neet network.  Requires networkx.
+
+        :param labels: how node is labeled and thus identified in networkx graph 
+                       ('names' or 'indices')
+        :returns: a networkx DiGraph
+        """
+        if labels = 'names':
+            if hasattr(net,'names'):
+                labels = net.names
+            else:
+                raise ValueError("network nodes do not have names")
+
+        elif labels = 'indices':
+            labels = range(net.size)
+
+        else:
+            raise ValueError("labels must be 'names' or 'indices'")
+
+        edges = []
+        for i,label in enumerate(net.labels):
+            for j in net.neighbors_out(i):
+                edges.append((labels[i],labels[j]))
+
+        return nx.DiGraph(edges,name=net.metadata.get('name'))

--- a/neet/boolean/wtnetwork.py
+++ b/neet/boolean/wtnetwork.py
@@ -665,3 +665,48 @@ class WTNetwork(object):
             set([0, 1, 5, 8])
         """
         return self.neighbors_in(index) | self.neighbors_out(index)
+
+    def to_networkx_graph(self,labels='indices'):
+        """
+        Return networkx graph given neet network.  Requires networkx.
+
+        :param labels: how node is labeled and thus identified in networkx graph 
+                       ('names' or 'indices')
+        :returns: a networkx DiGraph
+        """
+        if labels == 'names':
+            if hasattr(self,'names'):
+                labels = self.names
+            else:
+                raise ValueError("network nodes do not have names")
+
+        elif labels == 'indices':
+            labels = range(self.size)
+
+        else:
+            raise ValueError("labels must be 'names' or 'indices'")
+
+        edges = []
+        for i,label in enumerate(labels):
+            for j in self.neighbors_out(i):
+                edges.append((labels[i],labels[j]))
+
+        return nx.DiGraph(edges,name=self.metadata.get('name'))
+
+    def draw(self,labels='indices',filename=None):
+        """
+        Output a file with a simple network drawing.  
+        
+        Requires networkx and pygraphviz.
+        
+        Supported image formats are determined by graphviz.  In particular,
+        pdf support requires 'cairo' and 'pango' to be installed prior to
+        graphviz installation.
+
+        :param labels: how node is labeled and thus identified in networkx graph 
+                   ('names' or 'indices'), only used if network is a LogicNetwork or WTNetwork
+        :param filename: filename to write drawing to. Temporary filename will be used if no filename provided.
+        :returns: a pygraphviz network drawing
+        
+        """        
+        nx.nx_agraph.view_pygraphviz(self.to_networkx_graph(labels=labels),prog='circo',path=filename)

--- a/neet/interfaces.py
+++ b/neet/interfaces.py
@@ -125,17 +125,25 @@ def neighbors(net, index, direction='both', **kwargs):
     else:
         return neighbor_types[direction](index)
 
-def to_networkx_graph(net,labels='indices'):
+def to_networkx_graph(net,labels='indices',**kwargs):
     """
     Return networkx graph given neet network.  Requires networkx.
 
     :param labels: how node is labeled and thus identified in networkx graph 
-                   ('names' or 'indices')
-    :returns: a networkx DiGraph
+                   ('names' or 'indices'), only used if network is a LogicNetwork or WTNetwork
+    :kwarg size: size of ECA, required if network is an ECA
+    :returns : a networkx DiGraph
     """
-    return net.to_networkx_graph(labels)
+    if net.__class__.__name__ == 'ECA':
+        if 'size' not in kwargs:
+            raise AttributeError("A `size` kwarg is required for converting an neet ECA to a networkx network")
+        else:
+            return net.to_networkx_graph(size)
 
-def draw(net,labels='indices',filename=None):
+    elif net.__class__.__name__ in ['WTNetwork','LogicNetwork']:
+        return net.to_networkx_graph(labels)
+
+def draw(net,labels='indices',filename=None,**kwargs):
     """
     Output a file with a simple network drawing.  
     
@@ -144,7 +152,21 @@ def draw(net,labels='indices',filename=None):
     Supported image formats are determined by graphviz.  In particular,
     pdf support requires 'cairo' and 'pango' to be installed prior to
     graphviz installation.
+
+    :param labels: how node is labeled and thus identified in networkx graph 
+                   ('names' or 'indices'), only used if network is a LogicNetwork or WTNetwork
+    :param filename: filename to write drawing to. Temporary filename will be used if no filename provided.
+    :kwarg size: size of ECA, required if network is an ECA
+    :returns: a pygraphviz network drawing
     """
+    if net.__class__.__name__ == 'ECA':
+        if 'size' not in kwargs:
+            raise AttributeError("A `size` kwarg is required for drawing an ECA")
+        else:
+            return net.draw(size,filename=filename)
+
+    elif net.__class__.__name__ in ['WTNetwork','LogicNetwork']:
+        return net.draw(labels=labels,filename=filename)
     net.draw(labels=labels,filename=filename)
 
 

--- a/neet/interfaces.py
+++ b/neet/interfaces.py
@@ -2,8 +2,6 @@
 # Use of this source code is governed by a MIT
 # license that can be found in the LICENSE file.
 
-import networkx as nx
-
 def is_network(thing):
     """
     Determine whether an *object* or *type* meets the interface requirement of

--- a/neet/interfaces.py
+++ b/neet/interfaces.py
@@ -125,18 +125,17 @@ def neighbors(net, index, direction='both', **kwargs):
     else:
         return neighbor_types[direction](index)
 
-def to_networkx_graph(net):
+def to_networkx_graph(net,labels='indices'):
     """
     Return networkx graph given neet network.  Requires networkx.
-    """
-    edges = []
-    names = net.names
-    for i,jSet in enumerate(net.neighbors(direction='out')):
-        for j in jSet:
-            edges.append((names[i],names[j]))
-    return nx.DiGraph(edges,name=net.metadata.get('name'))
 
-def draw(net,format='pdf',filename=None):
+    :param labels: how node is labeled and thus identified in networkx graph 
+                   ('names' or 'indices')
+    :returns: a networkx DiGraph
+    """
+    return net.to_networkx_graph(labels)
+
+def draw(net,labels='indices',filename=None):
     """
     Output a file with a simple network drawing.  
     
@@ -146,7 +145,31 @@ def draw(net,format='pdf',filename=None):
     pdf support requires 'cairo' and 'pango' to be installed prior to
     graphviz installation.
     """
-    if filename is None: filename = net.metadata.get('name','network')
-    if not filename.endswith('.'+format): filename += '.'+format
-    g = to_networkx_graph(net)
-    nx.nx_agraph.view_pygraphviz(g,prog='circo',path=filename)
+    net.draw(labels=labels,filename=filename)
+
+
+# def to_networkx_graph(net):
+#     """
+#     Return networkx graph given neet network.  Requires networkx.
+#     """
+#     edges = []
+#     names = net.names
+#     for i,jSet in enumerate(net.neighbors(direction='out')):
+#         for j in jSet:
+#             edges.append((names[i],names[j]))
+#     return nx.DiGraph(edges,name=net.metadata.get('name'))
+
+# def draw(net,format='pdf',filename=None):
+#     """
+#     Output a file with a simple network drawing.  
+    
+#     Requires networkx and pygraphviz.
+    
+#     Supported image formats are determined by graphviz.  In particular,
+#     pdf support requires 'cairo' and 'pango' to be installed prior to
+#     graphviz installation.
+#     """
+#     if filename is None: filename = net.metadata.get('name','network')
+#     if not filename.endswith('.'+format): filename += '.'+format
+#     g = to_networkx_graph(net)
+#     nx.nx_agraph.view_pygraphviz(g,prog='circo',path=filename)

--- a/test/test_boolean.py
+++ b/test/test_boolean.py
@@ -693,6 +693,30 @@ class TestWTNetwork(unittest.TestCase):
 
         self.assertEqual(net.neighbors(2),set([0, 1, 5, 8]))
 
+    def to_networkx_graph_names(self):
+        from neet.boolean.examples import s_pombe
+
+        nx_net = to_networkx_graph(s_pombe,labels='names')
+        self.assertEqual(list(nx_net),s_pombe.names)
+
+    def to_networkx_graph_names_fail(self):
+        net = bnet.WTNetwork([[1,0],[0,1]])
+
+        with self.assertRaises(ValueError):
+            to_networkx_graph(net,labels='names')
+
+    def to_networkx_metadata(self):
+        from neet.boolean.examples import s_pombe
+
+        nx_net = to_networkx_graph(net,labels='indices')
+
+        self.assertEqual(nx_net.graph['name'],'s_pombe')
+        self.assertEqual(nx_net.graph['name'],net.metadata['name'])
+
+    # def test_draw(self):
+    #     net = bnet.LogicNetwork([((0,), {'0'})])
+    #     draw(net,labels='indices')
+
         
 
 

--- a/test/test_eca.py
+++ b/test/test_eca.py
@@ -402,3 +402,13 @@ class TestECA(unittest.TestCase):
 
         self.assertEqual(net.neighbors(2, 4),set([1,2,3]))
 
+    def to_networkx_metadata(self):
+        net = ca.ECA(30)
+        net.boundary = (1,0)
+
+        nx_net = to_networkx_graph(net,3)
+
+        self.assertEqual(nx_net.graph['code'],30)
+        self.assertEqual(nx_net.graph['size'],3)
+        self.assertEqual(nx_net.graph['boundary'],(1,0))
+

--- a/test/test_interfaces.py
+++ b/test/test_interfaces.py
@@ -111,6 +111,15 @@ class TestCore(unittest.TestCase):
     def test_neighbors_IsNetwork(self):
         net = self.IsNetwork()
 
+    def test_to_networkx_graph(self):
+        net = bnet.LogicNetwork([((0,), {'0'})])
+        to_networkx_graph(net,labels='indices')
+
+    def test_draw(self):
+        net = bnet.LogicNetwork([((0,), {'0'})])
+        draw(net,labels='indices')
+
+
         # with self.assertRaises(AttributeError):
         #     neighbors(net)
 

--- a/test/test_interfaces.py
+++ b/test/test_interfaces.py
@@ -113,11 +113,12 @@ class TestCore(unittest.TestCase):
 
     def test_to_networkx_graph(self):
         net = bnet.LogicNetwork([((0,), {'0'})])
-        to_networkx_graph(net,labels='indices')
+        nx_net = to_networkx_graph(net,labels='indices')
+        self.assertEqual(list(nx_net),[0])
 
-    def test_draw(self):
-        net = bnet.LogicNetwork([((0,), {'0'})])
-        draw(net,labels='indices')
+    # def test_draw(self):
+    #     net = bnet.LogicNetwork([((0,), {'0'})])
+    #     draw(net,labels='indices')
 
 
         # with self.assertRaises(AttributeError):

--- a/test/test_logic.py
+++ b/test/test_logic.py
@@ -264,3 +264,29 @@ class TestLogicNetwork(unittest.TestCase):
         self.assertEqual(net.table,
                          [((0,), {'1'}),
                           ((1,), {'1'})])
+
+    def to_networkx_graph_names(self):
+        net = LogicNetwork([((1, 2), {'01', '10'}),
+                                    ((0, 2), ((0, 1), '10', [1, 1])),
+                                    ((0, 1), {'11'})], ['A', 'B', 'C'])
+
+        nx_net = to_networkx_graph(net,labels='names')
+        self.assertEqual(list(nx_net),['A', 'B', 'C'])
+
+    def to_networkx_graph_names_fail(self):
+        net = bnet.LogicNetwork([((0,), {'0'})])
+
+        with self.assertRaises(ValueError):
+            to_networkx_graph(net,labels='names')
+
+    def to_networkx_metadata(self):
+        net = bnet.LogicNetwork([((0,), {'0'})])
+        net.metadata['name']='net_name'
+
+        nx_net = to_networkx_graph(net,labels='indices')
+
+        self.assertEqual(nx_net.graph['name'],net.metadata['name'])
+
+    # def test_draw(self):
+    #     net = bnet.LogicNetwork([((0,), {'0'})])
+    #     draw(net,labels='indices')


### PR DESCRIPTION
Hey Brian,

I took your `to_networkx_graph()` interface function, and made it more robust, while keeping the code organization similar to other functions (ie the main functionalities are methods of the network types, and not in interface). I added some simple tests to the `to_networkx_graph()`. I slightly modified the required input for the draw function to remove the conflicting parameters that the user could modify.

However, I didn't write any tests for draw, or test, because I can't get graphviz to install on my machine for whatever reason. Perhaps you could test the draw to see if it works ok.